### PR TITLE
Fix #3: frame no longer overlaps connections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -220,13 +220,6 @@ body { font-family: Inter, system-ui, sans-serif; background: #fff; }
   overflow: hidden;
 }
 
-.react-flow__node-frame {
-  z-index: 1 !important;
-}
-
-.react-flow__node-block {
-  z-index: 10 !important;
-}
 
 .rf-frame--selected {
   box-shadow: 0 0 0 2px #93c5fd, 0 8px 18px rgba(15, 23, 42, 0.1);

--- a/src/App.css
+++ b/src/App.css
@@ -225,6 +225,10 @@ body { font-family: Inter, system-ui, sans-serif; background: #fff; }
   box-shadow: 0 0 0 2px #93c5fd, 0 8px 18px rgba(15, 23, 42, 0.1);
 }
 
+.rf-frame--dragging {
+  opacity: 0.55;
+}
+
 .rf-frame__title {
   padding: 10px 12px;
   font-weight: 600;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -159,9 +159,12 @@ function BlockNode({ data, selected }) {
   );
 }
 
-function FrameNode({ data, selected }) {
+function FrameNode({ data, selected, dragging }) {
   return (
-    <div className={`rf-frame ${selected ? 'rf-frame--selected' : ''}`} style={{ borderStyle: data.frameBorderStyle || 'solid' }}>
+    <div
+      className={`rf-frame ${selected ? 'rf-frame--selected' : ''} ${dragging ? 'rf-frame--dragging' : ''}`}
+      style={{ borderStyle: data.frameBorderStyle || 'solid' }}
+    >
       <NodeResizer isVisible={selected} minWidth={240} minHeight={160} lineStyle={{ borderColor: '#93c5fd' }} />
       <div
         className="rf-frame__title"
@@ -873,6 +876,7 @@ function DiagramApp() {
         <ReactFlow
           nodes={renderedNodes}
           edges={renderedEdges}
+          elevateNodesOnSelect={false}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -267,6 +267,7 @@ function DiagramApp() {
     () =>
       nodes.map((n) => ({
         ...n,
+        zIndex: n.type === 'frame' ? -1 : 10,
         data: {
           ...n.data,
           nodeId: n.id,


### PR DESCRIPTION
## Что сделано\n- Принудительно выставлен  при рендере нод: , \n- Удалены CSS-хаки  для , которые не гарантировали правильный порядок с рёбрами\n\n## Проверка\n- 
> home-schematic@0.0.0 build
> vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 198 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.46 kB │ gzip:   0.30 kB
dist/assets/index-DmOnxtUQ.css   15.19 kB │ gzip:   3.46 kB
dist/assets/index-GVpM0KCk.js   371.03 kB │ gzip: 116.28 kB
✓ built in 468ms\n- Локально: фрейм остаётся под связями и блоками\n\nCloses #3